### PR TITLE
Implement scaffolding for System Settings, and implemented configurable Saving Throw names.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "useTabs": false,
+  "printWidth": 100
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -160,8 +160,9 @@
   "BASICFANTASYRPG.EffectEdit": "Edit Effect",
   "BASICFANTASYRPG.EffectDelete": "Delete Effect",
 
-  "BASICFANTASYRPG.AutoRollTokenHP.name": "Automatically Roll Token HP",
-  "BASICFANTASYRPG.AutoRollTokenHP.hint": "Based on HD value. If this setting is turned off, HP will be set to TODO WORK OUT WHAT",
-
+  "BASICFANTASYRPG.Settings.SavesMenu.name": "Edit Saving Throw Names",
+  "BASICFANTASYRPG.Settings.SavesMenu.label": "Saving Throw Settings",
+  "BASICFANTASYRPG.Settings.SavesMenu.hint": "",
   "BASICFANTASYRPG.SaveName.hint": "Custom name for this saving throw. The same name is used for all players."
+
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -159,6 +159,9 @@
   "BASICFANTASYRPG.EffectToggle": "Toggle Effect",
   "BASICFANTASYRPG.EffectEdit": "Edit Effect",
   "BASICFANTASYRPG.EffectDelete": "Delete Effect",
+
   "BASICFANTASYRPG.AutoRollTokenHP.name": "Automatically Roll Token HP",
-  "BASICFANTASYRPG.AutoRollTokenHP.hint": "Based on HD value. If this setting is turned off, HP will be set to TODO WORK OUT WHAT"
+  "BASICFANTASYRPG.AutoRollTokenHP.hint": "Based on HD value. If this setting is turned off, HP will be set to TODO WORK OUT WHAT",
+
+  "BASICFANTASYRPG.SaveName.hint": "Custom name for this saving throw. The same name is used for all players."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -158,5 +158,7 @@
   "BASICFANTASYRPG.EffectCreate": "Create Effect",
   "BASICFANTASYRPG.EffectToggle": "Toggle Effect",
   "BASICFANTASYRPG.EffectEdit": "Edit Effect",
-  "BASICFANTASYRPG.EffectDelete": "Delete Effect"
+  "BASICFANTASYRPG.EffectDelete": "Delete Effect",
+  "BASICFANTASYRPG.AutoRollTokenHP.name": "Automatically Roll Token HP",
+  "BASICFANTASYRPG.AutoRollTokenHP.hint": "Based on HD value. If this setting is turned off, HP will be set to TODO WORK OUT WHAT"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -160,7 +160,7 @@
   "BASICFANTASYRPG.EffectEdit": "Edit Effect",
   "BASICFANTASYRPG.EffectDelete": "Delete Effect",
 
-  "BASICFANTASYRPG.Settings.SavesMenu.name": "Edit Saving Throw Names",
+  "BASICFANTASYRPG.Settings.SavesMenu.name": "Configure Saving Throw Names",
   "BASICFANTASYRPG.Settings.SavesMenu.label": "Saving Throw Settings",
   "BASICFANTASYRPG.Settings.SavesMenu.hint": "",
   "BASICFANTASYRPG.SaveName.hint": "Custom name for this saving throw. The same name is used for all players."

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -158,5 +158,10 @@
   "BASICFANTASYRPG.EffectCreate": "Créer un Effet",
   "BASICFANTASYRPG.EffectToggle": "Effet On/Off",
   "BASICFANTASYRPG.EffectEdit": "Modifier l'Effet",
-  "BASICFANTASYRPG.EffectDelete": "Supprimer l'Effet"
+  "BASICFANTASYRPG.EffectDelete": "Supprimer l'Effet",
+
+  "BASICFANTASYRPG.AutoRollTokenHP.name": "Automatically Roll Token HP",
+  "BASICFANTASYRPG.AutoRollTokenHP.hint": "Based on HD value. If this setting is turned off, HP will be set to TODO WORK OUT WHAT",
+
+  "BASICFANTASYRPG.SaveName.hint": "Custom name for this saving throw. The same name is used for all players."
 }

--- a/module/basicfantasyrpg.mjs
+++ b/module/basicfantasyrpg.mjs
@@ -7,6 +7,7 @@ import { BasicFantasyRPGItemSheet } from './sheets/item-sheet.mjs';
 // Import helper/utility classes and constants.
 import { preloadHandlebarsTemplates } from './helpers/templates.mjs';
 import { BASICFANTASYRPG } from './helpers/config.mjs';
+import { registerSettings } from './settings/settings.mjs';
 
 /* -------------------------------------------- */
 /*  Init Hook                                   */
@@ -109,6 +110,19 @@ Handlebars.registerPartial('iconRanged', `<i class="fa-solid fa-crosshairs fa-2x
 /* -------------------------------------------- */
 /*  Ready Hook & Others                         */
 /* -------------------------------------------- */
+
+/**
+ * Since feature #69 plans to have customisable saving throw names
+ * with localised default values, Register settings cannot be 
+ * called any earlier in the Foundry load process than i18Init.
+ * This event is early in the process, just after Init, but we 
+ * need to be careful that any initialisation which requires a setting
+ * can either handle the settings not being available, or is done after
+ * this event.
+ */ 
+Hooks.once('i18nInit', () => {
+  registerSettings()
+})
 
 Hooks.once('ready', async function() {
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to

--- a/module/helpers/settings.mjs
+++ b/module/helpers/settings.mjs
@@ -1,0 +1,17 @@
+// not the greatest approach, but
+export function objectsShallowEqual (obj1, obj2) {
+  const entries1 = Object.entries(obj1)
+  const entries2 = Object.entries(obj2)
+
+  if (entries1.length !== entries2.length) {
+    return false
+  }
+
+  for (let [key, value] of entries1) {
+    if (obj2[key] !== value) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/module/settings/saves-settings.mjs
+++ b/module/settings/saves-settings.mjs
@@ -40,7 +40,7 @@ class SavesSettings extends FormApplication {
     return foundry.utils.mergeObject(super.defaultOptions, {
       popOut: true,
       width: 400,
-      template: `systems/${SYSTEM_ID}/templates/settings/saves-settings.hbs`,
+      template: `systems/${SYSTEM_ID}/templates/settings/string-array-settings.hbs`,
       id: SETTINGS.SAVES_MENU,
       title: 'BASICFANTASYRPG.Settings.SavesMenu.name',
     })
@@ -55,6 +55,7 @@ class SavesSettings extends FormApplication {
         id: v,
         label: SavesSettings.defaultSaves[v],
         value: initialValues[v],
+        required: true,
       }
     })
     return data

--- a/module/settings/saves-settings.mjs
+++ b/module/settings/saves-settings.mjs
@@ -94,5 +94,6 @@ class SavesSettings extends FormApplication {
         element[0].value = game.i18n.localize(`BASICFANTASYRPG.Save${id.capitalize()}`)
       }
     })
+    ui.notifications.notify(game.i18n.localize('SETTINGS.ResetInfo'))
   }
 }

--- a/module/settings/saves-settings.mjs
+++ b/module/settings/saves-settings.mjs
@@ -1,4 +1,3 @@
-// import { Helpers } from './helpers.mjs'
 import { objectsShallowEqual } from '../helpers/settings.mjs'
 import { SYSTEM_ID, SETTINGS } from './settings.mjs'
 
@@ -13,7 +12,7 @@ export function registerSavesSettings () {
     hint: 'BASICFANTASYRPG.Settings.SavesMenu.hint',
     icon: 'fas fa-cog',
     type: SavesSettings,
-    restricted: true // GM-only
+    restricted: true, // GM-only
   })
 
   // the settings object
@@ -21,7 +20,7 @@ export function registerSavesSettings () {
     scope: 'world',
     config: false,
     type: Object,
-    default: SavesSettings.defaultSaves
+    default: SavesSettings.defaultSaves,
   })
 }
 
@@ -31,9 +30,7 @@ class SavesSettings extends FormApplication {
     if (!SavesSettings.#defaultSaves) {
       SavesSettings.#defaultSaves = {}
       saves.forEach(s => {
-        SavesSettings.#defaultSaves[s] = game.i18n.localize(
-          `BASICFANTASYRPG.Save${s.capitalize()}`
-        )
+        SavesSettings.#defaultSaves[s] = game.i18n.localize(`BASICFANTASYRPG.Save${s.capitalize()}`)
       })
     }
     return SavesSettings.#defaultSaves
@@ -45,7 +42,7 @@ class SavesSettings extends FormApplication {
       width: 400,
       template: `systems/${SYSTEM_ID}/templates/settings/saves-settings.hbs`,
       id: SETTINGS.SAVES_MENU,
-      title: 'BASICFANTASYRPG.Settings.SavesMenu.name'
+      title: 'BASICFANTASYRPG.Settings.SavesMenu.name',
     })
   }
 
@@ -57,7 +54,7 @@ class SavesSettings extends FormApplication {
       data[i] = {
         id: v,
         label: SavesSettings.defaultSaves[v],
-        value: initialValues[v]
+        value: initialValues[v],
       }
     })
     return data
@@ -67,7 +64,10 @@ class SavesSettings extends FormApplication {
     const data = foundry.utils.expandObject(formData)
     const current = game.settings.get(SYSTEM_ID, SETTINGS.SAVES_SETTINGS)
 
-    // todo: trim whitespace from each string & escape html
+    // todo: escape html
+    for (let [k, v] of Object.entries(data)) {
+      data[k] = v.trim()
+    }
 
     if (!objectsShallowEqual(data, current)) {
       game.settings.set(SYSTEM_ID, SETTINGS.SAVES_SETTINGS, data)
@@ -85,9 +85,7 @@ class SavesSettings extends FormApplication {
     saves.forEach(id => {
       const element = $(event.delegateTarget).find(`[name=${id}]`)
       if (element && element.length > 0) {
-        element[0].value = game.i18n.localize(
-          `BASICFANTASYRPG.Save${id.capitalize()}`
-        )
+        element[0].value = game.i18n.localize(`BASICFANTASYRPG.Save${id.capitalize()}`)
       }
     })
   }

--- a/module/settings/saves-settings.mjs
+++ b/module/settings/saves-settings.mjs
@@ -65,8 +65,13 @@ class SavesSettings extends FormApplication {
     const data = foundry.utils.expandObject(formData)
     const current = game.settings.get(SYSTEM_ID, SETTINGS.SAVES_SETTINGS)
 
-    // todo: escape html
     for (let [k, v] of Object.entries(data)) {
+      // trim trailing and leading whitespace then strip out all HTML tags
+      // Has an unfortunate effect of deleting the entire string if someone types in '<Spells>'
+      // if we really want to strip HTML, then a library is the best bet.
+      // data[k] = v?.trim()?.replace(/<\/?[^>]+(>|$)/g, '')
+
+      // just do whitespace for now
       data[k] = v.trim()
     }
 

--- a/module/settings/saves-settings.mjs
+++ b/module/settings/saves-settings.mjs
@@ -1,0 +1,92 @@
+// import { Helpers } from './helpers.mjs'
+import { objectsShallowEqual } from '../helpers/settings.mjs'
+import { SYSTEM_ID, SETTINGS } from './settings.mjs'
+
+// Helper array of IDs we'll use in a few places
+const saves = ['death', 'wands', 'paralysis', 'breath', 'spells']
+
+export function registerSavesSettings () {
+  // The settings menu
+  game.settings.registerMenu(SYSTEM_ID, SETTINGS.SAVES_MENU, {
+    name: 'BASICFANTASYRPG.Settings.SavesMenu.name',
+    label: 'BASICFANTASYRPG.Settings.SavesMenu.label',
+    hint: 'BASICFANTASYRPG.Settings.SavesMenu.hint',
+    icon: 'fas fa-cog',
+    type: SavesSettings,
+    restricted: true // GM-only
+  })
+
+  // the settings object
+  game.settings.register(SYSTEM_ID, SETTINGS.SAVES_SETTINGS, {
+    scope: 'world',
+    config: false,
+    type: Object,
+    default: SavesSettings.defaultSaves
+  })
+}
+
+class SavesSettings extends FormApplication {
+  static #defaultSaves = null
+  static get defaultSaves () {
+    if (!SavesSettings.#defaultSaves) {
+      SavesSettings.#defaultSaves = {}
+      saves.forEach(s => {
+        SavesSettings.#defaultSaves[s] = game.i18n.localize(
+          `BASICFANTASYRPG.Save${s.capitalize()}`
+        )
+      })
+    }
+    return SavesSettings.#defaultSaves
+  }
+
+  static get defaultOptions () {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      popOut: true,
+      width: 400,
+      template: `systems/${SYSTEM_ID}/templates/settings/saves-settings.hbs`,
+      id: SETTINGS.SAVES_MENU,
+      title: 'BASICFANTASYRPG.Settings.SavesMenu.name'
+    })
+  }
+
+  getData () {
+    const initialValues = game.settings.get(SYSTEM_ID, SETTINGS.SAVES_SETTINGS)
+    // repack the current saves names into id, label and values for the form
+    const data = {}
+    saves.forEach((v, i) => {
+      data[i] = {
+        id: v,
+        label: SavesSettings.defaultSaves[v],
+        value: initialValues[v]
+      }
+    })
+    return data
+  }
+
+  _updateObject (event, formData) {
+    const data = foundry.utils.expandObject(formData)
+    const current = game.settings.get(SYSTEM_ID, SETTINGS.SAVES_SETTINGS)
+
+    if (!objectsShallowEqual(data, current)) {
+      game.settings.set(SYSTEM_ID, SETTINGS.SAVES_SETTINGS, data)
+      SettingsConfig.reloadConfirm({ world: true })
+    }
+  }
+
+  activateListeners (html) {
+    super.activateListeners(html)
+    html.on('click', '[data-action=reset]', this._handleResetButtonClicked)
+  }
+
+  async _handleResetButtonClicked (event) {
+    console.log('BFRPG | Reset save names to default values')
+    saves.forEach(id => {
+      const element = $(event.delegateTarget).find(`[name=${id}]`)
+      if (element && element.length > 0) {
+        element[0].value = game.i18n.localize(
+          `BASICFANTASYRPG.Save${id.capitalize()}`
+        )
+      }
+    })
+  }
+}

--- a/module/settings/saves-settings.mjs
+++ b/module/settings/saves-settings.mjs
@@ -67,6 +67,8 @@ class SavesSettings extends FormApplication {
     const data = foundry.utils.expandObject(formData)
     const current = game.settings.get(SYSTEM_ID, SETTINGS.SAVES_SETTINGS)
 
+    // todo: trim whitespace from each string & escape html
+
     if (!objectsShallowEqual(data, current)) {
       game.settings.set(SYSTEM_ID, SETTINGS.SAVES_SETTINGS, data)
       SettingsConfig.reloadConfirm({ world: true })

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -2,7 +2,12 @@
  * pseudo-enum to make setting ID references less error prone
  */
 export const SETTINGS = {
-  AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP'
+  AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP',
+  SAVE_DEATH_NAME: 'saveDeathName',
+  SAVE_WANDS_NAME: 'saveWandsName',
+  SAVE_PARALYSIS_NAME: 'saveParalysisName',
+  SAVE_BREATH_NAME: 'saveBreathName',
+  SAVE_SPELLS_NAME: 'saveSpellsName',
 }
 
 // Use this internally for now. Refactoring the whole system is too big a job!
@@ -21,6 +26,72 @@ export function registerSettings () {
     type: Boolean,
     default: true,
     requiresReload: false,
-    restricted: true,  // GM-only setting
+    restricted: true // GM-only setting
   })
+
+  /**
+   * Saving throw customisation.
+   * If we get too many settings, these could be broken out into a submenu.
+   * It's more coding work, but keeps things together for the users.
+   */
+  // Death Ray or Poison
+  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_DEATH_NAME, {
+    name: 'BASICFANTASYRPG.SaveDeath',
+    hint: 'BASICFANTASYRPG.SaveName.hint',
+    scope: 'world',
+    config: true,
+    type: String,
+    default: game.i18n.localize('BASICFANTASYRPG.SaveDeath'),
+    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
+    restricted: true // GM-only setting
+  })
+
+  //   "BASICFANTASYRPG.SaveWands": "Magic Wands",
+  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_WANDS_NAME, {
+    name: 'BASICFANTASYRPG.SaveWands',
+    hint: 'BASICFANTASYRPG.SaveName.hint',
+    scope: 'world',
+    config: true,
+    type: String,
+    default: game.i18n.localize('BASICFANTASYRPG.SaveWands'),
+    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
+    restricted: true // GM-only setting
+  })
+
+  //   "BASICFANTASYRPG.SaveParalysis": "Paralysis or Petrify",
+  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_PARALYSIS_NAME, {
+    name: 'BASICFANTASYRPG.SaveParalysis',
+    hint: 'BASICFANTASYRPG.SaveName.hint',
+    scope: 'world',
+    config: true,
+    type: String,
+    default: game.i18n.localize('BASICFANTASYRPG.SaveParalysis'),
+    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
+    restricted: true // GM-only setting
+  })
+
+  //   "BASICFANTASYRPG.SaveBreath": "Dragon Breath",
+  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_BREATH_NAME, {
+    name: 'BASICFANTASYRPG.SaveBreath',
+    hint: 'BASICFANTASYRPG.SaveName.hint',
+    scope: 'world',
+    config: true,
+    type: String,
+    default: game.i18n.localize('BASICFANTASYRPG.SaveBreath'),
+    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
+    restricted: true // GM-only setting
+  })
+
+  //   "BASICFANTASYRPG.SaveSpells": "Rods, Staves, and Spells",
+  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_SPELLS_NAME, {
+    name: 'BASICFANTASYRPG.SaveSpells',
+    hint: 'BASICFANTASYRPG.SaveName.hint',
+    scope: 'world',
+    config: true,
+    type: String,
+    default: game.i18n.localize('BASICFANTASYRPG.SaveSpells'),
+    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
+    restricted: true // GM-only setting
+  })
+
 }

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -5,20 +5,11 @@ import { registerSavesSettings } from './saves-settings.mjs'
  * pseudo-enum to make setting ID references less error prone
  */
 export const SETTINGS = {
-  //   AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP',
-  // use the saves keys as the setting ID to make retrieval easy.
-  // So long as the system.key is unique, it's fine.
-  SAVE_DEATH_NAME: 'death',
-  SAVE_WANDS_NAME: 'wands',
-  SAVE_PARALYSIS_NAME: 'paralysis',
-  SAVE_BREATH_NAME: 'breath',
-  SAVE_SPELLS_NAME: 'spells',
-
   SAVES_MENU: 'savesMenu',
-  SAVES_SETTINGS: 'savesSettings'
+  SAVES_SETTINGS: 'savesSettings',
 }
 
-// Use this internally for now. Refactoring the whole system is too big a job!
+// Use this just for settings for now. Refactoring the whole system is too big a job!
 export const SYSTEM_ID = 'basicfantasyrpg'
 
 /**
@@ -29,27 +20,23 @@ export const SYSTEM_ID = 'basicfantasyrpg'
  * flag to show a setting to GM users is only supported for a setting
  * menu, not a setting itself.
  */
-const GM_ONLY_SETTINGS = [
-//   SETTINGS.SAVE_DEATH_NAME,
-//   SETTINGS.SAVE_WANDS_NAME,
-//   SETTINGS.SAVE_PARALYSIS_NAME,
-//   SETTINGS.SAVE_BREATH_NAME,
-//   SETTINGS.SAVE_SPELLS_NAME
-]
+const GM_ONLY_SETTINGS = []
 
 Hooks.on('renderSettingsConfig', (app, [html], context) => {
   if (game.user.isGM) return
 
   GM_ONLY_SETTINGS.forEach(id => {
-    html
-      .querySelector(`.form-group[data-setting-id="${SYSTEM_ID}.${id}"]`)
-      ?.remove()
+    html.querySelector(`.form-group[data-setting-id="${SYSTEM_ID}.${id}"]`)?.remove()
   })
 })
 
 export function registerSettings () {
   /**
-   * If we have any settings submenus, they'd be defined in separate files and called from here.
+   * register settings menus
    */
-    registerSavesSettings()
+  registerSavesSettings()
+
+  /**
+   * register top-level settings
+   */
 }

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -2,7 +2,7 @@
  * pseudo-enum to make setting ID references less error prone
  */
 export const SETTINGS = {
-  AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP',
+//   AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP',
   SAVE_DEATH_NAME: 'saveDeathName',
   SAVE_WANDS_NAME: 'saveWandsName',
   SAVE_PARALYSIS_NAME: 'saveParalysisName',
@@ -18,6 +18,9 @@ export function registerSettings () {
    * If we have any settings submenus, they'd be defined in separate files and called from here.
    */
 
+  /*
+  Disabled for now based on https://discord.com/channels/735808783493890058/1307906023444582430/1309772596103086081
+  Will delete later once confirmed that it's the wrong direction.
   game.settings.register(SYSTEM_ID, SETTINGS.AUTO_ROLL_TOKEN_HP, {
     name: 'BASICFANTASYRPG.AutoRollTokenHP.name',
     hint: 'BASICFANTASYRPG.AutoRollTokenHP.hint',
@@ -28,6 +31,7 @@ export function registerSettings () {
     requiresReload: false,
     restricted: true // GM-only setting
   })
+*/
 
   /**
    * Saving throw customisation.

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -1,2 +1,26 @@
+/**
+ * pseudo-enum to make setting ID references less error prone
+ */
+export const SETTINGS = {
+  AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP'
+}
+
+// Use this internally for now. Refactoring the whole system is too big a job!
+const SYSTEM_ID = 'basicfantasyrpg'
+
 export function registerSettings () {
+  /**
+   * If we have any settings submenus, they'd be defined in separate files and called from here.
+   */
+
+  game.settings.register(SYSTEM_ID, SETTINGS.AUTO_ROLL_TOKEN_HP, {
+    name: 'BASICFANTASYRPG.AutoRollTokenHP.name',
+    hint: 'BASICFANTASYRPG.AutoRollTokenHP.hint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: true,
+    requiresReload: false,
+    restricted: true,  // GM-only setting
+  })
 }

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -1,0 +1,2 @@
+export function registerSettings () {
+}

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -1,17 +1,21 @@
-import { BASICFANTASYRPG } from "../helpers/config.mjs"
+import { BASICFANTASYRPG } from '../helpers/config.mjs'
+import { registerSavesSettings } from './saves-settings.mjs'
 
 /**
  * pseudo-enum to make setting ID references less error prone
  */
 export const SETTINGS = {
-//   AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP',
-  // use the saves keys as the setting ID to make retrieval easy. 
+  //   AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP',
+  // use the saves keys as the setting ID to make retrieval easy.
   // So long as the system.key is unique, it's fine.
   SAVE_DEATH_NAME: 'death',
   SAVE_WANDS_NAME: 'wands',
   SAVE_PARALYSIS_NAME: 'paralysis',
   SAVE_BREATH_NAME: 'breath',
   SAVE_SPELLS_NAME: 'spells',
+
+  SAVES_MENU: 'savesMenu',
+  SAVES_SETTINGS: 'savesSettings'
 }
 
 // Use this internally for now. Refactoring the whole system is too big a job!
@@ -22,103 +26,30 @@ export const SYSTEM_ID = 'basicfantasyrpg'
  * non-GM users. We iterate the array in the renderSettingsConfig
  * hook and remove those settings from the DOM when required.
  * This workaround is necessary because in Foundry v12, a restricted
- * flag to show a setting to GM users is only supported for a setting 
+ * flag to show a setting to GM users is only supported for a setting
  * menu, not a setting itself.
  */
 const GM_ONLY_SETTINGS = [
-  SETTINGS.SAVE_DEATH_NAME,
-  SETTINGS.SAVE_WANDS_NAME,
-  SETTINGS.SAVE_PARALYSIS_NAME,
-  SETTINGS.SAVE_BREATH_NAME,
-  SETTINGS.SAVE_SPELLS_NAME,
+//   SETTINGS.SAVE_DEATH_NAME,
+//   SETTINGS.SAVE_WANDS_NAME,
+//   SETTINGS.SAVE_PARALYSIS_NAME,
+//   SETTINGS.SAVE_BREATH_NAME,
+//   SETTINGS.SAVE_SPELLS_NAME
 ]
 
 Hooks.on('renderSettingsConfig', (app, [html], context) => {
-    if (game.user.isGM) return
+  if (game.user.isGM) return
 
-    GM_ONLY_SETTINGS.forEach(id => {
-        html.querySelector(`.form-group[data-setting-id="${SYSTEM_ID}.${id}"]`)?.remove()
-    })
+  GM_ONLY_SETTINGS.forEach(id => {
+    html
+      .querySelector(`.form-group[data-setting-id="${SYSTEM_ID}.${id}"]`)
+      ?.remove()
+  })
 })
-
 
 export function registerSettings () {
   /**
    * If we have any settings submenus, they'd be defined in separate files and called from here.
    */
-
-  /*
-  Disabled for now based on https://discord.com/channels/735808783493890058/1307906023444582430/1309772596103086081
-  Will delete later once confirmed that it's the wrong direction.
-  game.settings.register(SYSTEM_ID, SETTINGS.AUTO_ROLL_TOKEN_HP, {
-    name: 'BASICFANTASYRPG.AutoRollTokenHP.name',
-    hint: 'BASICFANTASYRPG.AutoRollTokenHP.hint',
-    scope: 'world',
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: false,
-  })
-*/
-
-  /**
-   * Saving throw customisation.
-   * If we get too many settings, these could be broken out into a submenu.
-   * It's more coding work, but keeps things together for the users.
-   */
-  // Death Ray or Poison
-  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_DEATH_NAME, {
-    name: 'BASICFANTASYRPG.SaveDeath',
-    hint: 'BASICFANTASYRPG.SaveName.hint',
-    scope: 'world',
-    config: true,
-    type: String,
-    default: game.i18n.localize('BASICFANTASYRPG.SaveDeath'),
-    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-  })
-
-  //   "BASICFANTASYRPG.SaveWands": "Magic Wands",
-  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_WANDS_NAME, {
-    name: 'BASICFANTASYRPG.SaveWands',
-    hint: 'BASICFANTASYRPG.SaveName.hint',
-    scope: 'world',
-    config: true,
-    type: String,
-    default: game.i18n.localize('BASICFANTASYRPG.SaveWands'),
-    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-  })
-
-  //   "BASICFANTASYRPG.SaveParalysis": "Paralysis or Petrify",
-  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_PARALYSIS_NAME, {
-    name: 'BASICFANTASYRPG.SaveParalysis',
-    hint: 'BASICFANTASYRPG.SaveName.hint',
-    scope: 'world',
-    config: true,
-    type: String,
-    default: game.i18n.localize('BASICFANTASYRPG.SaveParalysis'),
-    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-  })
-
-  //   "BASICFANTASYRPG.SaveBreath": "Dragon Breath",
-  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_BREATH_NAME, {
-    name: 'BASICFANTASYRPG.SaveBreath',
-    hint: 'BASICFANTASYRPG.SaveName.hint',
-    scope: 'world',
-    config: true,
-    type: String,
-    default: game.i18n.localize('BASICFANTASYRPG.SaveBreath'),
-    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-  })
-
-  //   "BASICFANTASYRPG.SaveSpells": "Rods, Staves, and Spells",
-  game.settings.register(SYSTEM_ID, SETTINGS.SAVE_SPELLS_NAME, {
-    name: 'BASICFANTASYRPG.SaveSpells',
-    hint: 'BASICFANTASYRPG.SaveName.hint',
-    scope: 'world',
-    config: true,
-    type: String,
-    default: game.i18n.localize('BASICFANTASYRPG.SaveSpells'),
-    requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-  })
-
+    registerSavesSettings()
 }

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -1,17 +1,21 @@
+import { BASICFANTASYRPG } from "../helpers/config.mjs"
+
 /**
  * pseudo-enum to make setting ID references less error prone
  */
 export const SETTINGS = {
 //   AUTO_ROLL_TOKEN_HP: 'autoRollTokenHP',
-  SAVE_DEATH_NAME: 'saveDeathName',
-  SAVE_WANDS_NAME: 'saveWandsName',
-  SAVE_PARALYSIS_NAME: 'saveParalysisName',
-  SAVE_BREATH_NAME: 'saveBreathName',
-  SAVE_SPELLS_NAME: 'saveSpellsName',
+  // use the saves keys as the setting ID to make retrieval easy. 
+  // So long as the system.key is unique, it's fine.
+  SAVE_DEATH_NAME: 'death',
+  SAVE_WANDS_NAME: 'wands',
+  SAVE_PARALYSIS_NAME: 'paralysis',
+  SAVE_BREATH_NAME: 'breath',
+  SAVE_SPELLS_NAME: 'spells',
 }
 
 // Use this internally for now. Refactoring the whole system is too big a job!
-const SYSTEM_ID = 'basicfantasyrpg'
+export const SYSTEM_ID = 'basicfantasyrpg'
 
 /**
  * Array of setting IDs for the settings that should be hidden from

--- a/module/settings/settings.mjs
+++ b/module/settings/settings.mjs
@@ -13,6 +13,31 @@ export const SETTINGS = {
 // Use this internally for now. Refactoring the whole system is too big a job!
 const SYSTEM_ID = 'basicfantasyrpg'
 
+/**
+ * Array of setting IDs for the settings that should be hidden from
+ * non-GM users. We iterate the array in the renderSettingsConfig
+ * hook and remove those settings from the DOM when required.
+ * This workaround is necessary because in Foundry v12, a restricted
+ * flag to show a setting to GM users is only supported for a setting 
+ * menu, not a setting itself.
+ */
+const GM_ONLY_SETTINGS = [
+  SETTINGS.SAVE_DEATH_NAME,
+  SETTINGS.SAVE_WANDS_NAME,
+  SETTINGS.SAVE_PARALYSIS_NAME,
+  SETTINGS.SAVE_BREATH_NAME,
+  SETTINGS.SAVE_SPELLS_NAME,
+]
+
+Hooks.on('renderSettingsConfig', (app, [html], context) => {
+    if (game.user.isGM) return
+
+    GM_ONLY_SETTINGS.forEach(id => {
+        html.querySelector(`.form-group[data-setting-id="${SYSTEM_ID}.${id}"]`)?.remove()
+    })
+})
+
+
 export function registerSettings () {
   /**
    * If we have any settings submenus, they'd be defined in separate files and called from here.
@@ -29,7 +54,6 @@ export function registerSettings () {
     type: Boolean,
     default: true,
     requiresReload: false,
-    restricted: true // GM-only setting
   })
 */
 
@@ -47,7 +71,6 @@ export function registerSettings () {
     type: String,
     default: game.i18n.localize('BASICFANTASYRPG.SaveDeath'),
     requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-    restricted: true // GM-only setting
   })
 
   //   "BASICFANTASYRPG.SaveWands": "Magic Wands",
@@ -59,7 +82,6 @@ export function registerSettings () {
     type: String,
     default: game.i18n.localize('BASICFANTASYRPG.SaveWands'),
     requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-    restricted: true // GM-only setting
   })
 
   //   "BASICFANTASYRPG.SaveParalysis": "Paralysis or Petrify",
@@ -71,7 +93,6 @@ export function registerSettings () {
     type: String,
     default: game.i18n.localize('BASICFANTASYRPG.SaveParalysis'),
     requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-    restricted: true // GM-only setting
   })
 
   //   "BASICFANTASYRPG.SaveBreath": "Dragon Breath",
@@ -83,7 +104,6 @@ export function registerSettings () {
     type: String,
     default: game.i18n.localize('BASICFANTASYRPG.SaveBreath'),
     requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-    restricted: true // GM-only setting
   })
 
   //   "BASICFANTASYRPG.SaveSpells": "Rods, Staves, and Spells",
@@ -95,7 +115,6 @@ export function registerSettings () {
     type: String,
     default: game.i18n.localize('BASICFANTASYRPG.SaveSpells'),
     requiresReload: true, // I assume this will need a reload to ensure everything is re-rendered
-    restricted: true // GM-only setting
   })
 
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,5 +1,6 @@
 import {successChatMessage} from '../helpers/chat.mjs';
 import {onManageActiveEffect, prepareActiveEffectCategories} from '../helpers/effects.mjs';
+import { SYSTEM_ID } from '../settings/settings.mjs';
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -85,7 +86,7 @@ export class BasicFantasyRPGActorSheet extends ActorSheet {
   _prepareActorData(context) {
     // Handle saves.
     for (let [k, v] of Object.entries(context.data.saves)) {
-      v.label = game.i18n.localize(CONFIG.BASICFANTASYRPG.saves[k]) ?? k;
+      v.label = game.settings.get(SYSTEM_ID, k) ?? k
     }
   }
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,6 +1,6 @@
 import {successChatMessage} from '../helpers/chat.mjs';
 import {onManageActiveEffect, prepareActiveEffectCategories} from '../helpers/effects.mjs';
-import { SYSTEM_ID } from '../settings/settings.mjs';
+import { SYSTEM_ID, SETTINGS } from '../settings/settings.mjs';
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -85,8 +85,9 @@ export class BasicFantasyRPGActorSheet extends ActorSheet {
    */
   _prepareActorData(context) {
     // Handle saves.
+    const savesNames = game.settings.get(SYSTEM_ID, SETTINGS.SAVES_SETTINGS)
     for (let [k, v] of Object.entries(context.data.saves)) {
-      v.label = game.settings.get(SYSTEM_ID, k) ?? k
+      v.label = savesNames[k] ?? k
     }
   }
 

--- a/styles/basicfantasyrpg.css
+++ b/styles/basicfantasyrpg.css
@@ -371,6 +371,16 @@
   width: 0;
 }
 
+.form-row {
+  margin: 5px;
+}
+
+.button-container {
+  display: flex;
+  gap: 10px;
+  margin-top: 5px;
+}
+
 /* Styles limited to basicfantasyrpg sheets */
 
 .basicfantasyrpg.sheet.actor {

--- a/styles/basicfantasyrpg.css
+++ b/styles/basicfantasyrpg.css
@@ -371,8 +371,16 @@
   width: 0;
 }
 
+/* Styles used in the settings forms */
 .form-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin: 5px;
+
+  .label {
+    vertical-align: middle;
+  }
 }
 
 .button-container {

--- a/templates/settings/saves-settings.hbs
+++ b/templates/settings/saves-settings.hbs
@@ -5,7 +5,6 @@
 </div>
 {{/inline}}
 
-{{log this}}
 <form class="form-group flexcol">
     <fieldset>
         <legend>{{localize "BASICFANTASYRPG.Settings.SavesMenu.name"}}:</legend>

--- a/templates/settings/saves-settings.hbs
+++ b/templates/settings/saves-settings.hbs
@@ -1,0 +1,25 @@
+{{#*inline "savePartial"}}
+<div class="form-row flexrow">
+    <label for="{{id}}">{{label}}:</label>
+    <input name="{{id}}" required=true value="{{value}}" />
+</div>
+{{/inline}}
+
+{{log this}}
+<form class="form-group flexcol">
+    <fieldset>
+        <legend>{{localize "BASICFANTASYRPG.Settings.SavesMenu.name"}}:</legend>
+        {{#each this}}
+        {{> savePartial}}
+        {{/each}}
+    </fieldset>
+
+    <footer class="sheet-footer flexrow button-container">
+        <button class="reset-all" type="button" name="reset" data-action="reset">
+            <i class="fa-solid fa-undo"></i> {{localize "SETTINGS.Reset"}}
+        </button>
+        <button type="submit" name="submit">
+            <i class="fa-solid fa-save"></i> {{localize "SETTINGS.Save"}}
+        </button>
+    </footer>
+</form>

--- a/templates/settings/string-array-settings.hbs
+++ b/templates/settings/string-array-settings.hbs
@@ -1,17 +1,18 @@
-{{#*inline "savePartial"}}
+{{!-- fa
+ --}}
+
+{{#*inline "stringFieldPartial"}}
 <div class="form-row flexrow">
     <label for="{{id}}">{{label}}:</label>
-    <input name="{{id}}" required=true value="{{value}}" />
+    <input name="{{id}}" {{#if required}}required="true"{{/if}} value="{{value}}" />
 </div>
 {{/inline}}
 
+{{log this}}
 <form class="form-group flexcol">
-    <fieldset>
-        <legend>{{localize "BASICFANTASYRPG.Settings.SavesMenu.name"}}:</legend>
-        {{#each this}}
-        {{> savePartial}}
-        {{/each}}
-    </fieldset>
+    {{#each this}}
+    {{> stringFieldPartial}}
+    {{/each}}
 
     <footer class="sheet-footer flexrow button-container">
         <button class="reset-all" type="button" name="reset" data-action="reset">

--- a/templates/settings/string-array-settings.hbs
+++ b/templates/settings/string-array-settings.hbs
@@ -4,7 +4,7 @@
 {{#*inline "stringFieldPartial"}}
 <div class="form-row flexrow">
     <label for="{{id}}">{{label}}:</label>
-    <input name="{{id}}" {{#if required}}required="true"{{/if}} value="{{value}}" />
+    <input name="{{id}}" type="text" {{#if required}}required="true"{{/if}} value="{{value}}" />
 </div>
 {{/inline}}
 


### PR DESCRIPTION
The basic approach is entirely data-driven
- The settings data object is built for the saving throws, with default values pulled from the localisation database
- The Actor sheet reads values from the system settings object instead of from localisation strings, using the same key as before.
- Default behaviour is identical: localised saving throw names identical to whatever is in the language files
- A GM-only settings menu allows the saving throw names to be overridden for the entire world in a small settings form. Form validation prevents empty strings. I apply simple string cleaning to strip whitespace from the start and end of the string. 
- There is commented out code that uses a regex to strip HTML tags from the strings, but given that Foundry allows GM and players to execute arbitrary client-side JS code anyway, I don't see that allowing unsanitised strings as saving throw names is really a problem. If it is, then I'd suggest that rather than rolling our own dodgy regex, we'd import a JS library and call that.
- Settings menus like I've used give good control over validation, but unfortunately they mean we don't get the free "reset defaults" function. I implemented this manually. It's not hard and it works.
- I'm quite happy with the overall approach. Everything is data-driven and agnostic with respect to the number of string items being handled in the settings. I think there's a nice general pattern emerging that could be abstracted further if this needs to be repeated for other things.