### PR TITLE
#76 release automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,22 @@
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'core feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels: 
+      - 'refactoring'
+      - 'maintenance'
+  - title: '📖 Documentation'
+    labels: 
+      - 'documentation'
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -1,0 +1,42 @@
+name: Release Creation
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Substitute the Manifest and Download URLs in the system.json
+      - name: Substitute Manifest and Download Links For Versioned Ones
+        id: sub_manifest_link_version
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: 'system.json'
+        env:
+          version: ${{github.event.release.tag_name}}
+          url: https://github.com/${{github.repository}}
+          manifest: https://github.com/${{github.repository}}/releases/latest/download/system.json
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}.zip
+
+      # Create a zip file with all files required by the module to add to the release
+      - run: zip -r ./${{github.event.release.tag_name}}.zip system.json template.json LICENSE lang/ module/ styles/ templates/
+
+      # Create a release for this specific version
+      - name: Update Release with Files
+        id: create_version_release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.event.release.name }}
+          allowUpdates: true # Set this to false if you want to prevent updating existing releases
+          draft: true
+          prerelease: false
+          artifacts: './system.json, ./${{ github.event.release.tag_name }}.zip'
+          tag: ${{ github.event.release.tag_name }}
+          body: ${{ github.event.release.body }}

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -35,7 +35,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ github.event.release.name }}
           allowUpdates: true # Set this to false if you want to prevent updating existing releases
-          draft: true
+          draft: false
           prerelease: false
           artifacts: './system.json, ./${{ github.event.release.tag_name }}.zip'
           tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -25,7 +25,7 @@ jobs:
           download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/basicfantasyrpg.zip
 
       # Create a zip file with all files required by the module to add to the release
-      - run: zip -r ./${{github.event.release.tag_name}}.zip system.json template.json LICENSE lang/ module/ styles/ templates/
+      - run: zip -r ./basicfantasyrpg.zip system.json template.json LICENSE lang/ module/ styles/ templates/
 
       # Create a release for this specific version
       - name: Update Release with Files
@@ -37,7 +37,6 @@ jobs:
           allowUpdates: true # Set this to false if you want to prevent updating existing releases
           draft: false
           prerelease: false
-          removeArtifacts: true  # does this remove the default artifacts?
-          artifacts: './system.json, ./${{ github.event.release.tag_name }}.zip'
+          artifacts: './system.json, ./basicfantasyrpg.zip'
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -22,7 +22,7 @@ jobs:
           version: ${{github.event.release.tag_name}}
           url: https://github.com/${{github.repository}}
           manifest: https://github.com/${{github.repository}}/releases/latest/download/system.json
-          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.name}}/${{github.event.release.tag_name}}.zip
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/basicfantasyrpg.zip
 
       # Create a zip file with all files required by the module to add to the release
       - run: zip -r ./${{github.event.release.tag_name}}.zip system.json template.json LICENSE lang/ module/ styles/ templates/

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -22,7 +22,7 @@ jobs:
           version: ${{github.event.release.tag_name}}
           url: https://github.com/${{github.repository}}
           manifest: https://github.com/${{github.repository}}/releases/latest/download/system.json
-          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}.zip
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.name}}/${{github.event.release.tag_name}}.zip
 
       # Create a zip file with all files required by the module to add to the release
       - run: zip -r ./${{github.event.release.tag_name}}.zip system.json template.json LICENSE lang/ module/ styles/ templates/
@@ -37,6 +37,7 @@ jobs:
           allowUpdates: true # Set this to false if you want to prevent updating existing releases
           draft: false
           prerelease: false
+          removeArtifacts: true  # does this remove the default artifacts?
           artifacts: './system.json, ./${{ github.event.release.tag_name }}.zip'
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,35 @@
+name: Release Drafter
+
+on:
+  # workflow_dispatch allows manual runs so the release notes can be rebuilt after PRs are renamed or relabeled
+  workflow_dispatch:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into main
+      - uses: release-drafter/release-drafter@v6
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the [Basic Fantasy RPG](https://www.basicfantasy.org/) system for Foundr
 This system is available within FoundryVTT, or you can manually install it by using the manifest link below:
 
 ```html
-https://github.com/DC23/basicfantasyrpg/releases/latest/download/system.json
+https://github.com/orffen/basicfantasyrpg/releases/latest/download/system.json
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # Basic Fantasy RPG for FoundryVTT
 
+![GitHub Release](https://img.shields.io/github/v/release/orffen/basicfantasyrpg?logo=GitHub&label=Release)
+[![Static Badge](https://img.shields.io/badge/Foundry%20Version-v11+-orange?logo=foundry-virtual-tabletop)](https://foundryvtt.com/)
+![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/orffen/basicfantasyrpg?logo=GitHub&label=Issues)
+![GitHub Issues or Pull Requests by label](https://img.shields.io/github/issues/orffen/basicfantasyrpg/bug?logo=GitHub&label=Open%20Bugs&color=red)
+![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/orffen/basicfantasyrpg/total?logo=GitHub&label=Total%20Downloads)
+![GitHub Downloads (all assets, latest release)](https://img.shields.io/github/downloads/orffen/basicfantasyrpg/latest/total?logo=GitHub&label=Downloads%3A%20Latest)
+
 This is the [Basic Fantasy RPG](https://www.basicfantasy.org/) system for FoundryVTT. Please also see the [companion compendium module](https://github.com/Stew-rt/basicfantasyrpg-corerules-en), which contains items, spells, monsters etc. for easy use with the system.
 
 ## Installation
 
 This system is available within FoundryVTT, or you can manually install it by using the manifest link below:
 
-https://raw.githubusercontent.com/orffen/basicfantasyrpg/main/system.json
+```html
+https://github.com/DC23/basicfantasyrpg/releases/latest/download/system.json
+```
 
 ## Usage
 


### PR DESCRIPTION
I've implemented two release automation workflows.

1. Release Drafter, which creates release notes from PR names and PR labels. The Release notes template is `.github/release-drafter.yml`. In the categories section you will see the mapping between labels and categories. I've used the categories I use on my other project. You can change these to suit. You don't have all the labels yet. Add what you need, adjust categories and it will all work. Note that a PR should only have a single label, or it gets added to the release notes twice. 

If you change the PR label or title later, the workflow can be run manually and it will update the notes while they are still in draft.

2. Release Creation: this one fills in the tags in the system.json, builds the zip, and publishes the new release. It doesn't update Foundry, I haven't sorted that part out yet.

For both, I have the workflows running with the minimum permissions possible, so you can reduce the default Actions workflow permissions from the default "read and write" to "read":
![image](https://github.com/user-attachments/assets/3f93dcb2-f6d2-48d3-a7f4-7360fb329467)

These two PRs should have no overlapping files, but you probably still want to merge this one first.